### PR TITLE
allow specifying uuid in options

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ export default defineConfig({
 });
 ```
 
+While the plugin can generate a uuid and save it in vite cache, you can also 
+specify it in the options like in the following:
+
+```
+  plugins: [
+    devtoolsJson({uuid "6ec0bd7f-11c0-43da-975e-2a8ad9ebae0b":}),
+    // ...
+  ]
+```
+
+
 The `/.well-known/appspecific/com.chrome.devtools.json` endpoint will serve the
 project settings as JSON with the following structure
 

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ export default defineConfig({
 });
 ```
 
-While the plugin can generate a uuid and save it in vite cache, you can also 
+While the plugin can generate a UUID and save it in vite cache, you can also 
 specify it in the options like in the following:
 
 ```
   plugins: [
-    devtoolsJson({uuid "6ec0bd7f-11c0-43da-975e-2a8ad9ebae0b":}),
+    devtoolsJson({uuid: "6ec0bd7f-11c0-43da-975e-2a8ad9ebae0b":}),
     // ...
   ]
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ interface DevToolsJSON {
 
 const ENDPOINT = '/.well-known/appspecific/com.chrome.devtools.json';
 
-const plugin = (): Plugin => ({
+const plugin = (options?: {uuid: string}): Plugin => ({
   name: 'devtools-json',
   enforce: 'post',
 
@@ -25,6 +25,9 @@ const plugin = (): Plugin => ({
     }
 
     const getOrCreateUUID = () => {
+      if (options?.uuid) {
+        return options.uuid;
+      }
       // Per https://vite.dev/config/shared-options.html#cachedir
       // the `config.cacheDir` can be either an absolute path, or
       // a path relative to project root (which in turn can be


### PR DESCRIPTION
I sometime need to clear the vite cache but would not want the chrome devtools workspace settings to change the uuid everytime I do it. so I added an option you can pass to the plugin to specify the uuid