### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ specify it in the options like in the following:
 
 ```
   plugins: [
-    devtoolsJson({uuid: "6ec0bd7f-11c0-43da-975e-2a8ad9ebae0b":}),
+    devtoolsJson({uuid: "6ec0bd7f-11c0-43da-975e-2a8ad9ebae0b"}),
     // ...
   ]
 ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ specify it in the options like in the following:
 
 ```
   plugins: [
-    devtoolsJson({uuid: "6ec0bd7f-11c0-43da-975e-2a8ad9ebae0b"}),
+    devtoolsJson({ uuid: "6ec0bd7f-11c0-43da-975e-2a8ad9ebae0b" }),
     // ...
   ]
 ```


### PR DESCRIPTION
There's an errant colon in a JavaScript sample in the README.  It's not a big deal, but just one more annoyance when copy/pasting.  Of course, the user will want to generate a different UUID, but it's just one extra thing.