### PR TITLE
feat: add projectRoot option and normalizeForChrome flag to devtools-json plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ specify it in the options like in the following:
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
 | `projectRoot` | `string` | `config.root` | Absolute path that will be reported to DevTools. Useful for monorepos or when the Vite root is not the desired folder. |
-| `normalizeForChrome` | `boolean` | `true` | Convert Linux paths to UNC form so Chrome on Windows (WSL / Docker Desktop) can mount them. Pass `false` to disable. |
+| `normalizeForWindowsContainer` | `boolean` | `true` | Convert Linux paths to UNC form so Chrome on Windows (WSL / Docker Desktop) can mount them (e.g. via WSL or Docker Desktop). Pass `false` to disable. <br/>_Alias:_ `normalizeForChrome` (deprecated)_ |
 | `uuid` | `string` | auto-generated | Fixed UUID if you prefer to control it yourself. |
 
 Example with all options:
@@ -58,7 +58,7 @@ export default defineConfig({
   plugins: [
     devtoolsJson({
       projectRoot: '/absolute/path/to/project',
-      normalizeForChrome: true,
+      normalizeForWindowsContainer: true,
       uuid: '6ec0bd7f-11c0-43da-975e-2a8ad9ebae0b'
     })
   ]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,30 @@ specify it in the options like in the following:
   ]
 ```
 
+### Options
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `projectRoot` | `string` | `config.root` | Absolute path that will be reported to DevTools. Useful for monorepos or when the Vite root is not the desired folder. |
+| `normalizeForChrome` | `boolean` | `true` | Convert Linux paths to UNC form so Chrome on Windows (WSL / Docker Desktop) can mount them. Pass `false` to disable. |
+| `uuid` | `string` | auto-generated | Fixed UUID if you prefer to control it yourself. |
+
+Example with all options:
+
+```js
+import { defineConfig } from 'vite';
+import devtoolsJson from 'vite-plugin-devtools-json';
+
+export default defineConfig({
+  plugins: [
+    devtoolsJson({
+      projectRoot: '/absolute/path/to/project',
+      normalizeForChrome: true,
+      uuid: '6ec0bd7f-11c0-43da-975e-2a8ad9ebae0b'
+    })
+  ]
+});
+```
 
 The `/.well-known/appspecific/com.chrome.devtools.json` endpoint will serve the
 project settings as JSON with the following structure


### PR DESCRIPTION
## What’s new

This PR introduces **two optional, fully backward-compatible settings** to `vite-plugin-devtools-json`:

| Option | Type | Default | Why it matters |
| ------ | ---- | ------- | -------------- |
| `projectRoot` | `string` | `config.root` | Explicit path that will be reported to Chrome DevTools.  Handy for monorepos or tools (like **Wasp**) where the desired workspace folder differs from Vite’s `root`. |
| `normalizeForChrome` | `boolean` | `true` | Keeps the current behaviour of rewriting Linux paths to UNC form (`\\wsl.localhost\…`) so Chrome running on Windows (WSL / Docker Desktop) can mount them.  Set to `false` to skip the rewrite. |

```ts
// vite.config.ts
import devtoolsJson from 'vite-plugin-devtools-json';

export default defineConfig({
  plugins: [
    devtoolsJson({
      projectRoot: '/abs/path/to/project',
      normalizeForChrome: false,   // opt-out if not needed
    })
  ]
});
```

## Implementation
* `src/index.ts` now accepts an `options: DevToolsJsonOptions` object.
* When provided, `projectRoot` overrides automatic root detection.
* UNC rewrite is done only when `normalizeForChrome !== false`.
* Existing `uuid` handling unchanged.

## Tests & build
* Added two Vitest specs covering the new options.
* All tests pass and `npm run build` succeeds.

## Motivation
While integrating this plugin into **Wasp** (our project) we needed:
1. A stable way to specify the true project root (the generated app lives in a subfolder).
2. Control over UNC rewriting for CI environments where it isn’t required.