### PR TITLE
don't log message when creating uuid.json

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,6 @@ const plugin = (options: DevToolsJsonOptions = {}): Plugin => ({
       }
       const uuid = v4();
       fs.writeFileSync(uuidPath, uuid, {encoding: 'utf-8'});
-      logger.info(`Generated UUID '${uuid}' for DevTools project settings.`);
       return uuid;
     };
 


### PR DESCRIPTION
When Chrome started requesting `com.chrome.devtools.json`, a lot of developers understandably started wondering why their frameworks were suddenly printing 404 messages in the terminal, and opened issues seeking help. [This one](https://github.com/sveltejs/kit/issues/13743) (I work on SvelteKit) is a good example of the resulting confusion and frustration.

If I can be blunt: it's disappointing that the first time most of us learned about Automatic Workspaces was because of issues like this. If there had been more outreach before taking what seems like a fairly drastic action (which levies an ongoing tax on developer tooling), we could at least have been ready to go with a remedy. Perhaps we could even have proposed alternative approaches, such as this — maybe there's a reason it wouldn't work, but we could at least have discussed it:

```js
function plugin(opts: DevToolsJsonOptions) {
  name: 'vite-plugin-devtools-json',
  configureServer(server) {
    server.middlewares.use((req, res, next) => {
      if (req.headers['sec-fetch-dest'] === 'document') {
        res.setHeader('x-devtools-json', getOrCreateDevtoolsJson(opts));
      }

      next();
    });
  }
}
```

I suspect that ship has sailed. Our hand was basically forced, and we created an [add-on](https://svelte.dev/docs/cli/devtools-json) for Svelte projects that installs this plugin.

In the meantime though it would really be appreciated if we could get rid of log that's printed when `uuid.json` is created. As a user this message means nothing to me — it's unclear where it came from (it's natural to assume that it came from the framework), it doesn't tell me anything useful, and I have no way to opt out of seeing it. It's just spam. At the _very_ least the message should be prefixed, as this one is...

https://github.com/ChromeDevTools/vite-plugin-devtools-json/blob/79f3aeffaa50d84febf9bad3aa36af38ec574047/src/index.ts#L95-L97

...(you could argue that Vite should be responsible for indicating this; that's a separate conversation), but getting rid of it altogether would be preferable.