### PR TITLE
respond with 404 during `vite preview`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -145,6 +145,12 @@ const plugin = (options: DevToolsJsonOptions = {}): Plugin => ({
       res.setHeader('Content-Type', 'application/json');
       res.end(JSON.stringify(devtoolsJson, null, 2));
     });
+  },
+  configurePreviewServer(server) {
+    server.middlewares.use(ENDPOINT, async (req, res) => {
+      res.writeHead(404);
+      res.end();
+    });
   }
 });
 


### PR DESCRIPTION
This plugin uses the `configureServer` hook, which serves a file during `vite dev`, but not the `configurePreviewServer` hook which is needed for `vite preview`. This causes spammy 'not found' messages.

Since it would be confusing to set up an automatic workspace when previewing a built project, it makes sense to respond with an empty 404.