### PR TITLE
Switch package to ESM module

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "vite-plugin-devtools-json",
   "version": "0.4.1",
   "description": "Vite plugin for generating `com.chrome.devtools.json` on the fly in the devserver.",
+  "type": "module",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",
   "module": "dist/index.mjs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
         "outDir": "dist",
         "target": "ES2020",
         "lib": ["ES2020"],
-        "types": ["node"]
+        "types": ["node"],
+        "skipLibCheck": true
     },
 
     "include": ["src/index.ts", "rollup.config.ts"]


### PR DESCRIPTION
Type check fails when the project consuming this plugin has `moduleResolution` set to `nodenext`. But this gets resolved if this package becomes an ESM module. So it would be better if this package can be an ESM package.

> [!NOTE]
> Additional Info: https://v6.vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated

## Example Error:

### `npx tsc -p ./tsconfig.json`
```sh
vite.config.ts:6:25 - error TS2349: This expression is not callable.
  Type 'typeof import("/tmp/fix-svelte-lib/node_modules/vite-plugin-devtools-json/dist/index")' has no call signatures.

6  plugins: [sveltekit(), devtoolsJson()]
                          ~~~~~~~~~~~~


Found 1 error in vite.config.ts:6
```