### PR TITLE
Update peerDependencies to include Vite 8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "homepage": "https://github.com/ChromeDevTools/vite-plugin-devtools-json#readme",
   "license": "MIT",
   "peerDependencies": {
-    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
+    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "dependencies": {
     "uuid": "^11.1.0"


### PR DESCRIPTION
This is same as [PR#26](https://github.com/ChromeDevTools/vite-plugin-devtools-json/pull/26). I am raising this again from my personal Github account. I also signed CLA.